### PR TITLE
Remove Pest config from Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,11 +45,5 @@
             "@test:types",
             "@test:unit"
         ]
-    },
-    "repositories": {
-        "pest": {
-            "type": "vcs",
-            "url": "https://github.com/pestphp/pest"
-        }
     }
 }


### PR DESCRIPTION
As Pest is now open source, do we require the config in the Composer JSON? 🤔